### PR TITLE
Adding missing bootstrap.js file

### DIFF
--- a/nativescript-sample-cuteness/app/bootstrap.js
+++ b/nativescript-sample-cuteness/app/bootstrap.js
@@ -1,0 +1,1 @@
+require("./app");


### PR DESCRIPTION
Ping @ErjanGavalji 

Cloning this project currently fails in AppBuilder because of a missing bootstrap.js module. This PR adds ones.